### PR TITLE
BAS-2592 Explicit install postgis 2.5 to fix "no candidate for.." error

### DIFF
--- a/postgres/Dockerfile
+++ b/postgres/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:10
 
 RUN apt-get update \
-	&& apt-get install -y postgresql-10-postgis-scripts openssh-client wget \
+	&& apt-get install -y postgresql-10-postgis-2.5-scripts openssh-client wget \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN echo 'max_wal_size = 2GB' >> "/usr/share/postgresql/$PG_MAJOR/postgresql.conf.sample"

--- a/postgres11/Dockerfile
+++ b/postgres11/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:11
 
 RUN apt-get update \
-	&& apt-get install -y postgresql-11-postgis-scripts openssh-client wget \
+	&& apt-get install -y postgresql-11-postgis-2.5-scripts openssh-client wget \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN echo 'max_wal_size = 2GB' >> "/usr/share/postgresql/$PG_MAJOR/postgresql.conf.sample"


### PR DESCRIPTION
Fixes this error:
Reading state information...
Package postgresql-10-postgis-scripts is a virtual package provided by:
  postgresql-10-postgis-3-scripts 3.0.0+dfsg-2~exp1.pgdg90+1
  postgresql-10-postgis-2.5-scripts 2.5.3+dfsg-2.pgdg90+1

E: Package 'postgresql-10-postgis-scripts' has no installation candidate
The command '/bin/sh -c apt-get update 	&& apt-get install -y postgresql-10-postgis-scripts openssh-client wget 	&& rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
Build step 'Execute shell' marked build as failure
Finished: FAILURE