### PR TITLE
Collapse unneeded layers in the python image + use dist-upgrade

### DIFF
--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -5,9 +5,6 @@ MAINTAINER datapunt@amsterdam.nl
 ENV PYTHONUNBUFFERED 1 \
     PIP_NO_CACHE_DIR=off
 
-COPY apt/stable.pref /etc/apt/preferences.d/
-COPY apt/stable.list /etc/apt/preferences.d/
-
 WORKDIR /app
 RUN apt-get update \
  && apt-get dist-upgrade -y \

--- a/python/Dockerfile
+++ b/python/Dockerfile
@@ -2,17 +2,17 @@ FROM python:3.7.2-stretch
 
 MAINTAINER datapunt@amsterdam.nl
 
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONUNBUFFERED 1 \
+    PIP_NO_CACHE_DIR=off
 
 COPY apt/stable.pref /etc/apt/preferences.d/
 COPY apt/stable.list /etc/apt/preferences.d/
 
 WORKDIR /app
-RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get autoremove -y
-
-RUN apt-get install -y \
+RUN apt-get update \
+ && apt-get dist-upgrade -y \
+ && apt-get autoremove -y \
+ && apt-get install -y \
         sudo \
         unzip \
         wget \
@@ -22,19 +22,18 @@ RUN apt-get install -y \
         netcat \
         libgeos-dev \
         gdal-bin \
-	postgresql-client-9.6 \
+        postgresql-client-9.6 \
         libgdal20 \
         libspatialite7 \
         libfreexl1 \
         libgeotiff2 \
         proj-bin \
+ && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \
  && pip install --upgrade pip \
- && pip install uwsgi
+ && pip install uwsgi \
+ && mkdir /usr/local/share/ca-certificates/extras
 
-
-RUN mkdir /usr/local/share/ca-certificates/extras
 COPY adp_rootca.crt /usr/local/share/ca-certificates/extras/
-RUN chmod 644 /usr/local/share/ca-certificates/extras/adp_rootca.crt
-RUN update-ca-certificates
-
-RUN adduser --system datapunt
+RUN chmod 644 /usr/local/share/ca-certificates/extras/adp_rootca.crt \
+ && update-ca-certificates \
+ && adduser --system datapunt

--- a/python/apt/stable.list
+++ b/python/apt/stable.list
@@ -1,4 +1,0 @@
-deb     http://ftp.nl.debian.org/debian/    stable main contrib non-free
-deb-src http://ftp.nl.debian.org/debian/    stable main contrib non-free
-#deb     http://ftp.nluug.nl/pub/os/Linux/distr/debian/    stable main contrib non-free
-#deb-src http://ftp.nluug.nl/pub/os/Linux/distr/debian/    stable main contrib non-free

--- a/python/apt/stable.pref
+++ b/python/apt/stable.pref
@@ -1,3 +1,0 @@
-Package: *
-Pin: release a=stable
-Pin-Priority: 900


### PR DESCRIPTION
This follows docker best practices:
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run

`docker history` shows this reduced the image from 30 to 24 layers.