### PR TITLE
Add python 3.8-buster image, and start using specific versioned tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Deze images zijn direct gebaseerd op de officiële images, maar hebben een aanta
 Gebruik
 =======
 
+Bouwen van deze images
+----------------------
+
+We hebben een interne parametrized Jenkins job die de volgende parameters toestaat:
+
+- `DOCKER_NAME`: naam van de map, die matched met the docker-image.
+- `DOCKER_TAG`: specifieke tag die gebouwd moet worden, er wordt dan een `Dockerfile.{tag}` gezocht.
+
+Het docker-compose bestand wordt niet gebruikt om de images te builden.
+
+
 Voor import processen op de datapunt infra:
 ------------------------------------------
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,5 +24,15 @@ services:
   python:
     build: python
 
+  python3.8-buster:
+    build:
+      context: python/
+      dockerfile: Dockerfile.3.8-buster
+
+  python3.8-slim-buster:
+    build:
+      context: python/
+      dockerfile: Dockerfile.3.8-slim-buster
+
   pointcloud:
     build: postgres_pointcloud

--- a/python/Dockerfile.3.8-buster
+++ b/python/Dockerfile.3.8-buster
@@ -1,0 +1,1 @@
+Dockerfile.3.8.1-buster

--- a/python/Dockerfile.3.8-slim-buster
+++ b/python/Dockerfile.3.8-slim-buster
@@ -1,0 +1,1 @@
+Dockerfile.3.8.1-slim-buster

--- a/python/Dockerfile.3.8.1-buster
+++ b/python/Dockerfile.3.8.1-buster
@@ -1,0 +1,35 @@
+FROM python:3.8.1-buster
+
+MAINTAINER datapunt@amsterdam.nl
+
+ENV PYTHONUNBUFFERED 1 \
+    PIP_NO_CACHE_DIR=off
+
+WORKDIR /app
+RUN apt-get update \
+ && apt-get dist-upgrade -y \
+ && apt-get autoremove -y \
+ && apt-get install -y \
+        unzip \
+        wget \
+        dnsutils \
+        vim-tiny \
+        net-tools \
+        netcat \
+        libgeos-dev \
+        gdal-bin \
+        postgresql-client-11 \
+        libgdal20 \
+        libspatialite7 \
+        libfreexl1 \
+        libgeotiff2 \
+        proj-bin \
+ && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \
+ && pip install --upgrade pip \
+ && pip install uwsgi \
+ && mkdir /usr/local/share/ca-certificates/extras
+
+COPY adp_rootca.crt /usr/local/share/ca-certificates/extras/
+RUN chmod 644 /usr/local/share/ca-certificates/extras/adp_rootca.crt \
+ && update-ca-certificates \
+ && useradd --user-group --system datapunt

--- a/python/Dockerfile.3.8.1-slim-buster
+++ b/python/Dockerfile.3.8.1-slim-buster
@@ -1,0 +1,34 @@
+FROM python:3.8.1-slim-buster
+
+MAINTAINER datapunt@amsterdam.nl
+
+ENV PYTHONUNBUFFERED 1 \
+    PIP_NO_CACHE_DIR=off
+
+WORKDIR /app
+RUN apt-get update \
+ && apt-get dist-upgrade -y \
+ && apt-get autoremove -y \
+ && apt-get install -y \
+        unzip \
+        wget \
+        dnsutils \
+        vim-tiny \
+        net-tools \
+        netcat \
+        libgeos-3.7 \
+        gdal-bin \
+        postgresql-client-11 \
+        libgdal20 \
+        libspatialite7 \
+        libfreexl1 \
+        libgeotiff2 \
+        proj-bin \
+ && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \
+ && pip install --upgrade pip \
+ && mkdir /usr/local/share/ca-certificates/extras
+
+COPY adp_rootca.crt /usr/local/share/ca-certificates/extras/
+RUN chmod 644 /usr/local/share/ca-certificates/extras/adp_rootca.crt \
+ && update-ca-certificates \
+ && useradd --user-group --system datapunt


### PR DESCRIPTION
The `Dockerfile.tagname` file can be used by the subtask in Jenkins to build the specific docker tag, and still use the same build context (for the `COPY` command)