### PR TITLE
Use --no-install-recommends for new Python dockers

### DIFF
--- a/python/Dockerfile.3.7.6-buster
+++ b/python/Dockerfile.3.7.6-buster
@@ -23,10 +23,15 @@ RUN apt-get update \
         libspatialite7 \
         libfreexl1 \
         libgeotiff2 \
+        libwebp-dev \
         proj-bin \
+        mime-support \
+        gettext \
  && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \
  && pip install --upgrade pip \
  && pip install uwsgi \
+ && echo "font/woff2    woff2" >> /etc/mime.types \
+ && echo "image/webp    webp"  >> /etc/mime.types \
  && mkdir /usr/local/share/ca-certificates/extras
 
 COPY adp_rootca.crt /usr/local/share/ca-certificates/extras/

--- a/python/Dockerfile.3.7.6-buster
+++ b/python/Dockerfile.3.7.6-buster
@@ -9,7 +9,7 @@ WORKDIR /app
 RUN apt-get update \
  && apt-get dist-upgrade -y \
  && apt-get autoremove -y \
- && apt-get install -y \
+ && apt-get install --no-install-recommends -y \
         unzip \
         wget \
         dnsutils \

--- a/python/Dockerfile.3.7.6-slim-buster
+++ b/python/Dockerfile.3.7.6-slim-buster
@@ -9,7 +9,7 @@ WORKDIR /app
 RUN apt-get update \
  && apt-get dist-upgrade -y \
  && apt-get autoremove -y \
- && apt-get install -y \
+ && apt-get install --no-install-recommends -y \
         unzip \
         wget \
         dnsutils \

--- a/python/Dockerfile.3.7.6-slim-buster
+++ b/python/Dockerfile.3.7.6-slim-buster
@@ -23,9 +23,19 @@ RUN apt-get update \
         libspatialite7 \
         libfreexl1 \
         libgeotiff2 \
+        libwebp6 \
         proj-bin \
+        mime-support \
+        gettext \
+        libwebpmux3 \
+        libwebpdemux2 \
+        libxml2 \
+        libfreetype6 \
+        libtiff5 \
  && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \
  && pip install --upgrade pip \
+ && echo "font/woff2    woff2" >> /etc/mime.types \
+ && echo "image/webp    webp"  >> /etc/mime.types \
  && mkdir /usr/local/share/ca-certificates/extras
 
 COPY adp_rootca.crt /usr/local/share/ca-certificates/extras/

--- a/python/Dockerfile.3.8.1-buster
+++ b/python/Dockerfile.3.8.1-buster
@@ -23,10 +23,15 @@ RUN apt-get update \
         libspatialite7 \
         libfreexl1 \
         libgeotiff2 \
+        libwebp-dev \
         proj-bin \
+        mime-support \
+        gettext \
  && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \
  && pip install --upgrade pip \
  && pip install uwsgi \
+ && echo "font/woff2    woff2" >> /etc/mime.types \
+ && echo "image/webp    webp"  >> /etc/mime.types \
  && mkdir /usr/local/share/ca-certificates/extras
 
 COPY adp_rootca.crt /usr/local/share/ca-certificates/extras/

--- a/python/Dockerfile.3.8.1-buster
+++ b/python/Dockerfile.3.8.1-buster
@@ -9,7 +9,7 @@ WORKDIR /app
 RUN apt-get update \
  && apt-get dist-upgrade -y \
  && apt-get autoremove -y \
- && apt-get install -y \
+ && apt-get install --no-install-recommends -y \
         unzip \
         wget \
         dnsutils \

--- a/python/Dockerfile.3.8.1-slim-buster
+++ b/python/Dockerfile.3.8.1-slim-buster
@@ -9,7 +9,7 @@ WORKDIR /app
 RUN apt-get update \
  && apt-get dist-upgrade -y \
  && apt-get autoremove -y \
- && apt-get install -y \
+ && apt-get install --no-install-recommends -y \
         unzip \
         wget \
         dnsutils \

--- a/python/Dockerfile.3.8.1-slim-buster
+++ b/python/Dockerfile.3.8.1-slim-buster
@@ -23,9 +23,19 @@ RUN apt-get update \
         libspatialite7 \
         libfreexl1 \
         libgeotiff2 \
+        libwebp6 \
         proj-bin \
+        mime-support \
+        gettext \
+        libwebpmux3 \
+        libwebpdemux2 \
+        libxml2 \
+        libfreetype6 \
+        libtiff5 \
  && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \
  && pip install --upgrade pip \
+ && echo "font/woff2    woff2" >> /etc/mime.types \
+ && echo "image/webp    webp"  >> /etc/mime.types \
  && mkdir /usr/local/share/ca-certificates/extras
 
 COPY adp_rootca.crt /usr/local/share/ca-certificates/extras/


### PR DESCRIPTION
This avoids installing a whole python 3.7.3 environment in /usr/ due to the recommendation of lsb-release.

The following packages were recommended by apt: `geoip-database libglib2.0-data shared-mime-info xdg-user-dirs krb5-locales libgpm2 poppler-data publicsuffix libsasl2-modules bzip2 file xz-utils lsb-release`

This also installed the following dependencies:

`distro-info-data libmagic-mgc libmagic1 libmpdec2 libpython3-stdlib libpython3.7-minimal libpython3.7-stdlib python3 python3-minimal python3.7 python3.7-minimal`

Looking at the code of github.com/amsterdam, no packages seem to depend on this.