### PR TITLE
Changed backup import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 Docker
 ======
 
-Images specifiek voor Datapunt development. 
-Deze images zijn direct gebaseerd op de officiële images, maar hebben een aantal hulp-scriptjes om alles wat makkelijker te maken. 
+Images specifiek voor Datapunt development.
+Deze images zijn direct gebaseerd op de officiële images, maar hebben een aantal hulp-scriptjes om alles wat makkelijker te maken.
 
 
 Gebruik
@@ -34,17 +34,20 @@ Voor lokale ontwikkelaars:
 -------------------------
 
 Binnen de projecten (of met deze Docker) kan je lokaal een actuele Acceptatie database of Elastic index inladen.
-Zorg dat als je lokaal de docker-compose gebruikt dat je private key deze locatie heeft: 
 
-    ~/.ssh/datapunt.key
-    
-Zo kan je dan de database of elastic updaten:    
 
+Database backup inladen
+-------------------------
 ```
-docker-compose run postgres update-db.sh <database> <username>
+docker-compose run postgres update-db.sh <database>
 ```
 
 of
+Elasticsearch backup inladen
+----------------------------
+Zorg dat als je lokaal de docker-compose gebruikt dat je private key deze locatie heeft:
+
+    ~/.ssh/datapunt.key
 
 ```
 docker-compose run elasticsearch6 update-el.sh <indexnaam> <username>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 version: '3.2'
 
+
+
 services:
   elasticsearch6:
     build: elasticsearch6
@@ -18,8 +20,8 @@ services:
 
   postgres11:
     build: postgres11
-    volumes:
-      - "~/.ssh/datapunt.key:/root/.ssh/datapunt.key"
+    extra_hosts:
+      admin.data.amsterdam.nl: 10.243.16.4
 
   python:
     build: python

--- a/postgres11/download-db.sh
+++ b/postgres11/download-db.sh
@@ -6,14 +6,12 @@ cd /tmp
 rm -f $1
 
 ENVIRONMENT=${ENVIRONMENT:-acceptance}
-if [ $# -eq 1 ] && [ ! -f $1_latest.gz ]; then
-    echo "User parameter not found: Using download ${ENVIRONMENT} for internal imports"
-    if [ "${ENVIRONMENT}" = "production" ]; then
-        wget -nc https://admin.data.amsterdam.nl/postgres_prod/$1_latest.gz
-    else
-        wget -nc https://admin.data.amsterdam.nl/postgres/$1_latest.gz
-    fi
-elif [ $# -eq 2 ] && [ ! -f $1_latest.gz ]; then
-    echo "User parameter found: Using download for developers"
-    scp -i ~/.ssh/datapunt.key $2@admin.data.amsterdam.nl:/mnt/backup_postgres/$1_latest.gz .
+if [ "${ENVIRONMENT}" = "production" ]; then
+        echo "Directly downloading production databases is no longer possible"
+fi
+
+if [ ! -f $1_latest.gz ]; then
+    echo "$1_latest.gz file does not exist, downloading backup"
+
+    wget -nc https://admin.data.amsterdam.nl/postgres/$1_latest.gz
 fi

--- a/postgres11/download-db.sh
+++ b/postgres11/download-db.sh
@@ -2,16 +2,18 @@
 set -eu
 set -x
 
-cd /tmp
-rm -f $1
+TARGET_FILE="/tmp/$1_latest.gz"
 
 ENVIRONMENT=${ENVIRONMENT:-acceptance}
-if [ "${ENVIRONMENT}" = "production" ]; then
-        echo "Directly downloading production databases is no longer possible"
+DOWNLOAD_URL="https://admin.data.amsterdam.nl/postgres/${1}_latest.gz"
+
+if [[ "${ENVIRONMENT}" = "production" ]]; then
+        echo "Directly downloading production backup is only possible from the CICD pipelines"
+        DOWNLOAD_URL="https://admin.data.amsterdam.nl/postgres_prod/${1}_latest.gz"
 fi
 
-if [ ! -f $1_latest.gz ]; then
+if [[ ! -f "${TARGET_FILE}" ]]; then
     echo "$1_latest.gz file does not exist, downloading backup"
 
-    wget -nc https://admin.data.amsterdam.nl/postgres/$1_latest.gz
+    wget -O "${TARGET_FILE}" -nc "${DOWNLOAD_URL}"
 fi


### PR DESCRIPTION
Use https for retrieving the backup instead of SCP. 
It's easier to maintain, has less security risks and the same auditing possibilities