### PR TITLE
Python 3.9.6 buster, slim-buster, buster-minimal, slim-buster-minimal

### DIFF
--- a/python/Dockerfile.3.9-buster
+++ b/python/Dockerfile.3.9-buster
@@ -1,1 +1,1 @@
-Dockerfile.3.9.0-buster
+Dockerfile.3.9.6-buster

--- a/python/Dockerfile.3.9-buster-minimal
+++ b/python/Dockerfile.3.9-buster-minimal
@@ -1,1 +1,1 @@
-Dockerfile.3.9.0-buster-minimal
+Dockerfile.3.9.6-buster-minimal

--- a/python/Dockerfile.3.9-slim-buster
+++ b/python/Dockerfile.3.9-slim-buster
@@ -1,1 +1,1 @@
-Dockerfile.3.9.0-slim-buster
+Dockerfile.3.9.6-slim-buster

--- a/python/Dockerfile.3.9-slim-buster-minimal
+++ b/python/Dockerfile.3.9-slim-buster-minimal
@@ -1,1 +1,1 @@
-Dockerfile.3.9.0-slim-buster-minimal
+Dockerfile.3.9.6-slim-buster-minimal

--- a/python/Dockerfile.3.9.6-buster
+++ b/python/Dockerfile.3.9.6-buster
@@ -1,0 +1,41 @@
+FROM python:3.9.6-buster
+
+MAINTAINER datapunt@amsterdam.nl
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=off \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
+WORKDIR /app
+
+COPY ca/* /usr/local/share/ca-certificates/extras/
+
+RUN apt-get update \
+ && apt-get dist-upgrade -y \
+ && apt-get autoremove -y \
+ && apt-get install --no-install-recommends -y \
+        unzip \
+        wget \
+        dnsutils \
+        vim-tiny \
+        net-tools \
+        netcat \
+        libgeos-dev \
+        gdal-bin \
+        postgresql-client-11 \
+        libgdal20 \
+        libspatialite7 \
+        libfreexl1 \
+        libgeotiff2 \
+        libwebp-dev \
+        proj-bin \
+        mime-support \
+        gettext \
+ && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \
+ && pip install --upgrade pip \
+ && pip install uwsgi \
+ && echo "font/woff2    woff2" >> /etc/mime.types \
+ && echo "image/webp    webp"  >> /etc/mime.types \
+ && chmod -R 644 /usr/local/share/ca-certificates/extras/ \
+ && update-ca-certificates \
+ && useradd --user-group --system datapunt

--- a/python/Dockerfile.3.9.6-buster-minimal
+++ b/python/Dockerfile.3.9.6-buster-minimal
@@ -1,0 +1,21 @@
+FROM python:3.9.6-buster
+
+MAINTAINER datapunt@amsterdam.nl
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=off \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
+WORKDIR /app
+RUN apt-get update \
+    && apt-get autoremove -y \
+    && apt-get install --no-install-recommends -y \
+           postgresql-client-11 \
+    && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \
+    && pip install --upgrade pip \
+    && mkdir /usr/local/share/ca-certificates/extras
+
+COPY ca/* /usr/local/share/ca-certificates/extras/
+RUN chmod -R 644 /usr/local/share/ca-certificates/extras/ \
+ && update-ca-certificates \
+ && useradd --user-group --system datapunt

--- a/python/Dockerfile.3.9.6-slim-buster
+++ b/python/Dockerfile.3.9.6-slim-buster
@@ -1,0 +1,45 @@
+FROM python:3.9.6-slim-buster
+
+MAINTAINER datapunt@amsterdam.nl
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=off \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
+WORKDIR /app
+
+COPY ca/* /usr/local/share/ca-certificates/extras/
+
+RUN apt-get update \
+ && apt-get dist-upgrade -y \
+ && apt-get autoremove -y \
+ && apt-get install --no-install-recommends -y \
+        unzip \
+        wget \
+        dnsutils \
+        vim-tiny \
+        net-tools \
+        netcat \
+        libgeos-3.7 \
+        gdal-bin \
+        postgresql-client-11 \
+        libgdal20 \
+        libspatialite7 \
+        libfreexl1 \
+        libgeotiff2 \
+        libwebp6 \
+        proj-bin \
+        mime-support \
+        gettext \
+        libwebpmux3 \
+        libwebpdemux2 \
+        libxml2 \
+        libfreetype6 \
+        libtiff5 \
+ && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \
+ && pip install --upgrade pip \
+ && echo "font/woff2    woff2" >> /etc/mime.types \
+ && echo "image/webp    webp"  >> /etc/mime.types \
+ && chmod -R 644 /usr/local/share/ca-certificates/extras/ \
+ && update-ca-certificates \
+ && useradd --user-group --system datapunt

--- a/python/Dockerfile.3.9.6-slim-buster-minimal
+++ b/python/Dockerfile.3.9.6-slim-buster-minimal
@@ -1,0 +1,20 @@
+FROM python:3.9.6-slim-buster
+
+MAINTAINER datapunt@amsterdam.nl
+
+ENV PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=off \
+    REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
+WORKDIR /app
+COPY ca/* /usr/local/share/ca-certificates/extras/
+
+RUN apt-get update \
+    && apt-get autoremove -y \
+    && apt-get install --no-install-recommends -y \
+           postgresql-client-11 \
+    && rm -rf /var/lib/apt/lists/* /var/cache/debconf/*-old \
+    && pip install --upgrade pip \
+    && chmod -R 644 /usr/local/share/ca-certificates/extras/ \
+    && update-ca-certificates \
+    && useradd --user-group --system datapunt


### PR DESCRIPTION
Added Python version 3.9.6 to the available docker images, moved the 3.9 symlink to point to 3.9.6.